### PR TITLE
Add an implementation of the algorithm for finding bridges

### DIFF
--- a/graphs-lab/src/main/kotlin/graphs_lab/algs/TarjanBridgeFinding.kt
+++ b/graphs-lab/src/main/kotlin/graphs_lab/algs/TarjanBridgeFinding.kt
@@ -6,31 +6,59 @@ import graphs_lab.algs.utils.removeAndReturn
 import graphs_lab.core.edges.Edge
 import graphs_lab.core.graphs.Graph
 
+/**
+ * The Tarjan's bridge-finding algorithm.
+ *
+ * Finding the bridges in an undirected graph.
+ * A bridge is an edge, when it is removed, the number of connectivity components increases.
+ *
+ * @references https://en.wikipedia.org/wiki/Bridge_(graph_theory)
+ *
+ * @param I the type of the vertex identifiers
+ * @param E the type of the edges in the graph
+ * @property graph the input graph
+ */
 class TarjanBridgeFinding<I, E : Edge<I>>(
 	val graph: Graph<I, E>
 ) {
-	private val table = mutableSetOf<Edge<I>>()
+	private val setBridges = mutableSetOf<Edge<I>>()
+
+	/**
+	 * [tableHeights] the map that associates the identifier of a vertex with a pair that consist of
+	 * the minimal height (in an imaginary tree) among the vertices connected by an inverse edge (in an imaginary tree)
+	 * to the vertices from the subtree with the associated vertex in root or the height (in an imaginary tree)
+	 * of the associated vertex and the height (in an imaginary tree) of the associated vertex.
+	 */
 	private val tableHeights = mutableMapOf<I, Pair<Int?, Int?>>()
-	private val listUnvisited = mutableListOf<I>()
+	private val listUnvisitedVertices = mutableListOf<I>()
 
 	init {
 		require(!graph.isDirected) { "Do not support directed graph." }
 	}
 
+	/**
+	 * @return [setBridges]
+	 * @throws IllegalStateException if there is an appeal to a non-existent identifier
+	 */
 	fun getBridges(): Set<Edge<I>> {
-		if (graph.idVertices.isEmpty()) return table
+		if (graph.idVertices.isEmpty()) return setBridges
 
 		graph.idVertices.forEach {
-			listUnvisited.add(it)
+			listUnvisitedVertices.add(it)
 		}
 
-		while (listUnvisited.isNotEmpty()) {
-			dfs(graph.vertexEdges(listUnvisited.removeFirst()), 1)
+		while (listUnvisitedVertices.isNotEmpty()) {
+			dfs(graph.vertexEdges(listUnvisitedVertices.removeFirst()), 1)
 		}
 
-		return table
+		return setBridges
 	}
 
+	/**
+	 * Goes down the tree to the depth and fills [tableHeights] in according to the definition.
+	 *
+	 * @throws IllegalStateException if there is an appeal to a non-existent identifier
+	 */
 	private fun dfs(setEdges: Set<Edge<I>>, height: Int) {
 		if (setEdges.isEmpty()) return
 
@@ -39,12 +67,12 @@ class TarjanBridgeFinding<I, E : Edge<I>>(
 		setEdges.forEach {
 			var temp: Int
 
-			if (tableHeights[it.idTarget] == null) {
-				dfs(graph.vertexEdges(listUnvisited.removeAndReturn(it.idTarget)), height + 1)
+			if (tableHeights[it.idTarget] == null) { // Means a straight edge (in an imaginary tree)
+				dfs(graph.vertexEdges(listUnvisitedVertices.removeAndReturn(it.idTarget)), height + 1)
 				temp = checkAndGetFirst(tableHeights[it.idTarget])
-			} else {
+			} else { // Means an inverse edge (in an imaginary tree)
 				temp = checkAndGetSecond(tableHeights[it.idTarget])
-				if (height - temp == 1) {
+				if (height - temp == 1) { // Avoids considering an inverse edge whose vertex heights differ by 1
 					temp = height
 				}
 			}
@@ -52,7 +80,7 @@ class TarjanBridgeFinding<I, E : Edge<I>>(
 			tableHeights[it.idSource] = Pair(minOf(temp, checkAndGetFirst(tableHeights[it.idSource])), height)
 
 			if (checkAndGetFirst(tableHeights[it.idTarget]) > height) {
-				table.add(it)
+				setBridges.add(it)
 			}
 		}
 	}

--- a/graphs-lab/src/main/kotlin/graphs_lab/algs/TarjanBridgeFinding.kt
+++ b/graphs-lab/src/main/kotlin/graphs_lab/algs/TarjanBridgeFinding.kt
@@ -10,7 +10,7 @@ import graphs_lab.core.graphs.Graph
  * The Tarjan's bridge-finding algorithm.
  *
  * Finding the bridges in an undirected graph.
- * A bridge is an edge, when it is removed, the number of connectivity components increases.
+ * A bridge is an edge of a graph whose deletion increases the graph's number of connected components.
  *
  * @references https://en.wikipedia.org/wiki/Bridge_(graph_theory)
  *

--- a/graphs-lab/src/main/kotlin/graphs_lab/algs/TarjanBridgeFinding.kt
+++ b/graphs-lab/src/main/kotlin/graphs_lab/algs/TarjanBridgeFinding.kt
@@ -1,5 +1,7 @@
 package graphs_lab.algs
 
+import graphs_lab.algs.utils.checkAndGetFirst
+import graphs_lab.algs.utils.checkAndGetSecond
 import graphs_lab.algs.utils.removeAndReturn
 import graphs_lab.core.edges.Edge
 import graphs_lab.core.graphs.Graph
@@ -7,19 +9,21 @@ import graphs_lab.core.graphs.Graph
 class TarjanBridgeFinding<I>(val graph: Graph<I, Edge<I>>) {
 	private val table = mutableSetOf<Edge<I>>()
 	private val tableHeights = mutableMapOf<I, Pair<Int?, Int?>>()
-	private val heapUnvisited = mutableListOf<I>()
+	private val listUnvisited = mutableListOf<I>()
 
 	init {
 		require(!graph.isDirected) { "Do not support directed graph." }
 	}
 
-	fun getBridges(): MutableSet<Edge<I>> {
+	fun getBridges(): Set<Edge<I>> {
 		if (graph.idVertices.isEmpty()) return table
 
-		graph.idVertices.forEach { heapUnvisited.add(it) }
+		graph.idVertices.forEach {
+			listUnvisited.add(it)
+		}
 
-		while (heapUnvisited.isNotEmpty()) {
-			dfs(graph.vertexEdges(heapUnvisited.removeFirst()), 1)
+		while (listUnvisited.isNotEmpty()) {
+			dfs(graph.vertexEdges(listUnvisited.removeFirst()), 1)
 		}
 
 		return table
@@ -34,7 +38,7 @@ class TarjanBridgeFinding<I>(val graph: Graph<I, Edge<I>>) {
 			var temp: Int
 
 			if (tableHeights[it.idTarget] == null) {
-				dfs(graph.vertexEdges(heapUnvisited.removeAndReturn(it.idTarget)), height + 1)
+				dfs(graph.vertexEdges(listUnvisited.removeAndReturn(it.idTarget)), height + 1)
 				temp = checkAndGetFirst(tableHeights[it.idTarget])
 			} else {
 				temp = checkAndGetSecond(tableHeights[it.idTarget])
@@ -49,13 +53,5 @@ class TarjanBridgeFinding<I>(val graph: Graph<I, Edge<I>>) {
 				table.add(it)
 			}
 		}
-	}
-
-	private fun checkAndGetFirst(pair: Pair<Int?, Int?>?): Int {
-		return pair?.first ?: throw ExceptionInInitializerError("Undefined behaviour: unfounded vertex.")
-	}
-
-	private fun checkAndGetSecond(pair: Pair<Int?, Int?>?): Int {
-		return pair?.second ?: throw ExceptionInInitializerError("Undefined behaviour: unfounded vertex.")
 	}
 }

--- a/graphs-lab/src/main/kotlin/graphs_lab/algs/TarjanBridgeFinding.kt
+++ b/graphs-lab/src/main/kotlin/graphs_lab/algs/TarjanBridgeFinding.kt
@@ -1,0 +1,61 @@
+package graphs_lab.algs
+
+import graphs_lab.algs.utils.removeAndReturn
+import graphs_lab.core.edges.Edge
+import graphs_lab.core.graphs.Graph
+
+class TarjanBridgeFinding<I>(val graph: Graph<I, Edge<I>>) {
+	private val table = mutableSetOf<Edge<I>>()
+	private val tableHeights = mutableMapOf<I, Pair<Int?, Int?>>()
+	private val heapUnvisited = mutableListOf<I>()
+
+	init {
+		require(!graph.isDirected) { "Do not support directed graph." }
+	}
+
+	fun getBridges(): MutableSet<Edge<I>> {
+		if (graph.idVertices.isEmpty()) return table
+
+		graph.idVertices.forEach { heapUnvisited.add(it) }
+
+		while (heapUnvisited.isNotEmpty()) {
+			dfs(graph.vertexEdges(heapUnvisited.removeFirst()), 1)
+		}
+
+		return table
+	}
+
+	private fun dfs(setEdges: Set<Edge<I>>, height: Int) {
+		if (setEdges.isEmpty()) return
+
+		tableHeights[setEdges.first().idSource] = Pair(height, height)
+
+		setEdges.forEach {
+			var temp: Int
+
+			if (tableHeights[it.idTarget] == null) {
+				dfs(graph.vertexEdges(heapUnvisited.removeAndReturn(it.idTarget)), height + 1)
+				temp = checkAndGetFirst(tableHeights[it.idTarget])
+			} else {
+				temp = checkAndGetSecond(tableHeights[it.idTarget])
+				if (height - temp == 1) {
+					temp = height
+				}
+			}
+
+			tableHeights[it.idSource] = Pair(minOf(temp, checkAndGetFirst(tableHeights[it.idSource])), height)
+
+			if (checkAndGetFirst(tableHeights[it.idTarget]) > height) {
+				table.add(it)
+			}
+		}
+	}
+
+	private fun checkAndGetFirst(pair: Pair<Int?, Int?>?): Int {
+		return pair?.first ?: throw ExceptionInInitializerError("Undefined behaviour: unfounded vertex.")
+	}
+
+	private fun checkAndGetSecond(pair: Pair<Int?, Int?>?): Int {
+		return pair?.second ?: throw ExceptionInInitializerError("Undefined behaviour: unfounded vertex.")
+	}
+}

--- a/graphs-lab/src/main/kotlin/graphs_lab/algs/TarjanBridgeFinding.kt
+++ b/graphs-lab/src/main/kotlin/graphs_lab/algs/TarjanBridgeFinding.kt
@@ -6,7 +6,9 @@ import graphs_lab.algs.utils.removeAndReturn
 import graphs_lab.core.edges.Edge
 import graphs_lab.core.graphs.Graph
 
-class TarjanBridgeFinding<I>(val graph: Graph<I, Edge<I>>) {
+class TarjanBridgeFinding<I, E : Edge<I>>(
+	val graph: Graph<I, E>
+) {
 	private val table = mutableSetOf<Edge<I>>()
 	private val tableHeights = mutableMapOf<I, Pair<Int?, Int?>>()
 	private val listUnvisited = mutableListOf<I>()

--- a/graphs-lab/src/main/kotlin/graphs_lab/algs/utils/Utils.kt
+++ b/graphs-lab/src/main/kotlin/graphs_lab/algs/utils/Utils.kt
@@ -26,7 +26,7 @@ fun <I, E : Edge<I>> getEdgeWeight(edge: E, defaultWeight: Double = 1.0): Double
  * @return the second element of the given pair
  * @throws ExceptionInInitializerError if the pair or the first element of it is null
  */
-fun <I, T> checkAndGetFirst(pair: Pair<I?, T>?): I {
+fun <I, T> checkAndGetFirst(pair: Pair<I?, T?>?): I {
 	return pair?.first ?: throw ExceptionInInitializerError("Undefined behaviour: an unfounded vertex.")
 }
 
@@ -38,6 +38,11 @@ fun <I, T> checkAndGetFirst(pair: Pair<I?, T>?): I {
  * @return the second element of the given pair
  * @throws ExceptionInInitializerError if the pair or the second element of it is null
  */
-fun <I, T> checkAndGetSecond(pair: Pair<I?, T>?): T {
+fun <I, T> checkAndGetSecond(pair: Pair<I?, T?>?): T {
 	return pair?.second ?: throw ExceptionInInitializerError("Undefined behaviour: an unfounded vertex.")
+}
+
+fun <I> MutableList<I>.removeAndReturn(item: I): I {
+	remove(item)
+	return item
 }

--- a/graphs-lab/src/main/kotlin/graphs_lab/algs/utils/Utils.kt
+++ b/graphs-lab/src/main/kotlin/graphs_lab/algs/utils/Utils.kt
@@ -42,6 +42,13 @@ fun <I, T> checkAndGetSecond(pair: Pair<I?, T?>?): T {
 	return pair?.second ?: throw ExceptionInInitializerError("Undefined behaviour: an unfounded vertex.")
 }
 
+/**
+ * Removes the given item from the list if the item is contained in it.
+ *
+ * @param item the item to be deleted
+ *
+ * @return [item] in any case
+ */
 fun <I> MutableList<I>.removeAndReturn(item: I): I {
 	remove(item)
 	return item

--- a/graphs-lab/src/test/kotlin/graphs_lab/algs/TestTarjanBridgeFinding.kt
+++ b/graphs-lab/src/test/kotlin/graphs_lab/algs/TestTarjanBridgeFinding.kt
@@ -1,6 +1,5 @@
 package graphs_lab.algs
 
-import graphs_lab.core.Vertex
 import graphs_lab.core.edges.Edge
 import graphs_lab.core.graphs.UnweightedGraph
 import graphs_lab.core.graphs.WeightedGraph

--- a/graphs-lab/src/test/kotlin/graphs_lab/algs/TestTarjanBridgeFinding.kt
+++ b/graphs-lab/src/test/kotlin/graphs_lab/algs/TestTarjanBridgeFinding.kt
@@ -1,0 +1,114 @@
+package graphs_lab.algs
+
+import graphs_lab.core.Vertex
+import graphs_lab.core.edges.Edge
+import graphs_lab.core.graphs.UnweightedGraph
+import graphs_lab.core.graphs.WeightedGraph
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class TestTarjanBridgeFinding {
+
+	@Test
+	@DisplayName("empty unweighted undirected graph")
+	fun testEmptyUnweightedUndirectedGraph() {
+		val graph = UnweightedGraph<Char>("Tarjan test", isDirected = false, isAutoAddVertex = true)
+
+		val graphTarjan = TarjanBridgeFinding(graph)
+		Assertions.assertEquals(graphTarjan.getBridges(), setOf<Char>())
+
+		Assertions.assertEquals(graphTarjan.graph, graph)
+	}
+
+	@Test
+	@DisplayName("empty unweighted directed graph")
+	fun testEmptyUnweightedDirectedGraph() {
+		val graph = UnweightedGraph<Char>("Tarjan test", isDirected = true, isAutoAddVertex = true)
+
+		Assertions.assertThrows(IllegalArgumentException::class.java) { TarjanBridgeFinding(graph) }
+	}
+
+	@Test
+	@DisplayName("one unweighted edge")
+	fun testOneUnweightedEdge() {
+		val graph = UnweightedGraph<Char>("Tarjan test", isDirected = false, isAutoAddVertex = true)
+		graph.addEdge('1', '2')
+
+		val graphTarjan = TarjanBridgeFinding(graph)
+		Assertions.assertEquals(graphTarjan.getBridges(), graph.vertexEdges('1'))
+	}
+
+	@Test
+	@DisplayName("one weighted edge")
+	fun testOneWeightedEdge() {
+		val graph = WeightedGraph<Char>("Tarjan test", isDirected = false, isAutoAddVertex = true)
+		graph.addEdge('1', '2', 1.0)
+
+		val graphTarjan = TarjanBridgeFinding(graph)
+		Assertions.assertEquals(graphTarjan.getBridges(), graph.vertexEdges('1'))
+	}
+
+	@Test
+	@DisplayName("unweighted connected graph")
+	fun testUnweightedConnectedGraph() {
+		val graph = UnweightedGraph<String>("Tarjan test", isDirected = false, isAutoAddVertex = true)
+
+		graph.addEdge("1", "2")
+		graph.addEdge("1", "5")
+		graph.addEdge("1", "10")
+		graph.addEdge("1", "13")
+		graph.addEdge("2", "13")
+		graph.addEdge("12", "13")
+		graph.addEdge("10", "11")
+		graph.addEdge("2", "3")
+		graph.addEdge("4", "3")
+		graph.addEdge("9", "3")
+		graph.addEdge("9", "8")
+		graph.addEdge("7", "8")
+		graph.addEdge("7", "6")
+		graph.addEdge("5", "6")
+
+		val graphTarjan = TarjanBridgeFinding(graph)
+		val setBridges = mutableSetOf<Edge<String>>()
+
+		setBridges.add(graph.vertexEdges("13").find { it.idTarget == "12" }!!)
+		setBridges.add(graph.vertexEdges("3").find { it.idTarget == "4" }!!)
+		setBridges.add(graph.vertexEdges("10").find { it.idTarget == "11" }!!)
+		setBridges.add(graph.vertexEdges("1").find { it.idTarget == "10" }!!)
+
+		Assertions.assertEquals(graphTarjan.getBridges(), setBridges)
+	}
+
+	@Test
+	@DisplayName("unweighted disconnected graph")
+	fun testUnweightedDisconnectedGraph() {
+		val graph = UnweightedGraph<String>("Tarjan test", isDirected = false, isAutoAddVertex = true)
+
+		graph.addEdge("1", "2")
+		graph.addEdge("1", "5")
+		graph.addEdge("1", "10")
+		graph.addEdge("1", "13")
+		graph.addEdge("2", "13")
+		graph.addEdge("12", "13")
+		graph.addEdge("2", "3")
+		graph.addEdge("4", "3")
+		graph.addEdge("9", "3")
+		graph.addEdge("9", "8")
+		graph.addEdge("5", "8")
+
+		graph.addVertex("11")
+
+		graph.addEdge("7", "6")
+
+		val graphTarjan = TarjanBridgeFinding(graph)
+		val setBridges = mutableSetOf<Edge<String>>()
+
+		setBridges.add(graph.vertexEdges("13").find { it.idTarget == "12" }!!)
+		setBridges.add(graph.vertexEdges("3").find { it.idTarget == "4" }!!)
+		setBridges.add(graph.vertexEdges("1").find { it.idTarget == "10" }!!)
+		setBridges.add(graph.vertexEdges("7").find { it.idTarget == "6" }!!)
+
+		Assertions.assertEquals(graphTarjan.getBridges(), setBridges)
+	}
+}

--- a/graphs-lab/src/test/kotlin/graphs_lab/algs/utils/TestUtils.kt
+++ b/graphs-lab/src/test/kotlin/graphs_lab/algs/utils/TestUtils.kt
@@ -43,7 +43,7 @@ class TestUtils {
 	@Test
 	@DisplayName("check and get the first element of the pair")
 	fun testCheckAndGetFirst() {
-		var pair: Pair<Char?, Int>? = null
+		var pair: Pair<Char?, Int?>? = null
 		Assertions.assertThrows(ExceptionInInitializerError::class.java) { checkAndGetFirst(pair) }
 
 		pair = Pair(null, 1)
@@ -56,7 +56,10 @@ class TestUtils {
 	@Test
 	@DisplayName("check and get the second element of the pair")
 	fun testCheckAndGetSecond() {
-		var pair: Pair<Char?, Int>? = null
+		var pair: Pair<Char?, Int?>? = null
+		Assertions.assertThrows(ExceptionInInitializerError::class.java) { checkAndGetSecond(pair) }
+
+		pair = Pair('A', null)
 		Assertions.assertThrows(ExceptionInInitializerError::class.java) { checkAndGetSecond(pair) }
 
 		pair = Pair('A', 1)


### PR DESCRIPTION
Добавлена реализация алгоритма поиска [мостов](https://en.wikipedia.org/wiki/Bridge_(graph_theory)):

- [Tarjan's bridge-finding algorithm](https://en.wikipedia.org/wiki/Bridge_(graph_theory)#Tarjan's_bridge-finding_algorithm).

Реализовал согласно следующему [источнику](https://otter18.github.io/algo179/b/bridge?ysclid=lvqze8etj6687902076). 