### PR TITLE
Update jacoco coverage output format

### DIFF
--- a/scripts/csv-reports-printer.py
+++ b/scripts/csv-reports-printer.py
@@ -68,6 +68,11 @@ def parse_args(args: list[str]) -> argparse.Namespace:
 
     return parser.parse_args(args)
 
+def set_as_even_number(number: int):
+    if (number % 2 == 0):
+        return number
+    return number + 1
+
 
 def read_csv(namespace: argparse.Namespace) -> typing.Optional[dict]:
     table = []
@@ -106,8 +111,8 @@ def read_csv(namespace: argparse.Namespace) -> typing.Optional[dict]:
                 table.append(row_info)
     return {
         "table": table,
-        "max_packages_name_length": max_packages_name_length,
-        "max_classes_name_length": max_classes_name_length
+        "max_packages_name_length": set_as_even_number(max_packages_name_length),
+        "max_classes_name_length": set_as_even_number(max_classes_name_length)
     }
 
 


### PR DESCRIPTION
Обновлена выборка максимальной длинны ячейки в столбце выводимой таблицы. Теперь длины привязаны к чётному числу, что улучшает формат вывода и исправляет проблему указанную в раделе issues #14.

closes #14 