### PR TITLE
Update file pick dialogs

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -21,7 +21,6 @@ dependencies {
 	implementation("org.xerial", "sqlite-jdbc", sqliteJdbcVersion)
 	implementation("io.github.microutils", "kotlin-logging-jvm", "2.0.6")
 	implementation("org.slf4j", "slf4j-simple", "1.7.29")
-	implementation("com.darkrockstudios:mpfilepicker:3.1.0")
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.8.1")
 }

--- a/application/src/main/kotlin/Main.kt
+++ b/application/src/main/kotlin/Main.kt
@@ -44,8 +44,8 @@ fun main() {
 
 		Window(
 			onCloseRequest = {
-				saveSettings(jetSettings)
-				saveHistory(mainScreenViewModel.homePageViewModel.previouslyLoadedGraph)
+				saveSettings(settings, jetSettings)
+				saveHistory(settings, mainScreenViewModel.homePageViewModel.previouslyLoadedGraph)
 				exitApplication()
 			},
 			title = "YMOM",
@@ -78,8 +78,8 @@ fun findOrCreateFile(file: File) {
  *
  * @param jetSettings an object that stores the current customization parameters
  */
-private fun saveSettings(jetSettings: JetSettings) {
-	val file = File("../settings")
+private fun saveSettings(settings: SettingsModel, jetSettings: JetSettings) {
+	val file = File(settings.applicationContextDirectory, ".settings")
 	findOrCreateFile(file)
 
 	file.writeText(
@@ -96,8 +96,8 @@ private fun saveSettings(jetSettings: JetSettings) {
  *
  * @param previouslyLoadedGraph a set of previously loaded graphs that will be saved
  */
-private fun saveHistory(previouslyLoadedGraph: List<GraphInfo>) {
-	val file = File("../history")
+private fun saveHistory(settings: SettingsModel, previouslyLoadedGraph: List<GraphInfo>) {
+	val file = File(settings.applicationContextDirectory, ".history")
 	findOrCreateFile(file)
 
 	file.writeText("")

--- a/application/src/main/kotlin/models/SettingsModel.kt
+++ b/application/src/main/kotlin/models/SettingsModel.kt
@@ -25,6 +25,7 @@ import java.sql.SQLException
  *
  * @property isNeo4jConnected indicates whether a Neo4J database is connected
  * @property graphNameRegEx a regular expression used to validate graph names
+ * @property applicationContextDirectory the directory of application context
  */
 class SettingsModel {
 	private val jsonDB = GraphJSONDatabase()
@@ -32,6 +33,13 @@ class SettingsModel {
 	private val sqliteDB = SQLiteRepository()
 	var isNeo4jConnected = false
 	val graphNameRegEx = Regex("[a-zA-Z][a-zA-Z0-9_-]*")
+	val applicationContextDirectory = File(System.getProperty("user.home"), "graph-lab")
+
+	init {
+		if (!applicationContextDirectory.exists()) {
+			applicationContextDirectory.mkdirs()
+		}
+	}
 
 	/**
 	 * Connects to a Neo4J database using the provided URI, username, and password.

--- a/application/src/main/kotlin/models/SettingsModel.kt
+++ b/application/src/main/kotlin/models/SettingsModel.kt
@@ -236,12 +236,13 @@ class SettingsModel {
 		 */
 		@JvmStatic
 		fun loadSettings(jetSettings: JetSettings): SettingsModel {
-			val file = File("../settings")
+			val settings = SettingsModel()
+			val file = File(settings.applicationContextDirectory, ".settings")
 
 			findOrCreateFile(file)
 			loadSettings(file, jetSettings)
 
-			return SettingsModel()
+			return settings
 		}
 
 		/**

--- a/application/src/main/kotlin/utils/GraphSavingType.kt
+++ b/application/src/main/kotlin/utils/GraphSavingType.kt
@@ -4,9 +4,9 @@ package utils
  * Enum of types to save graph objects in application.
  *
  * @property label simple string of name element
- * @constructor create graph saving type with custom label
+ * @property filenamePattern regular expression pattern to match filename of it file
  */
-enum class GraphSavingType(val label: String, val filenamePatterns: Regex? = null) {
+enum class GraphSavingType(val label: String, val filenamePattern: Regex? = null) {
 	LOCAL_FILE(
 		"Local file",
 		Regex("[a-zA-Z][a-zA-Z0-9_-]*.json")

--- a/application/src/main/kotlin/utils/GraphSavingType.kt
+++ b/application/src/main/kotlin/utils/GraphSavingType.kt
@@ -6,9 +6,15 @@ package utils
  * @property label simple string of name element
  * @constructor create graph saving type with custom label
  */
-enum class GraphSavingType(val label: String) {
-	LOCAL_FILE("Local file"),
-	SQLITE_DB("SQLite DB"),
+enum class GraphSavingType(val label: String, val filenamePatterns: Regex? = null) {
+	LOCAL_FILE(
+		"Local file",
+		Regex("[a-zA-Z][a-zA-Z0-9_-]*.json")
+	),
+	SQLITE_DB(
+		"SQLite DB",
+		Regex("[a-zA-Z][a-zA-Z0-9_-]*.db")
+	),
 	NEO4J_DB("Neo4j DB");
 
 	override fun toString(): String {

--- a/application/src/main/kotlin/utils/filedialogs/Algorithms.kt
+++ b/application/src/main/kotlin/utils/filedialogs/Algorithms.kt
@@ -1,0 +1,9 @@
+package utils.filedialogs
+
+import java.io.File
+
+fun filtrate(directory: File, filter: (File) -> Boolean): List<File> {
+	if (!directory.isDirectory || !directory.exists()) return emptyList()
+
+	return directory.listFiles()?.filter { filter(it) } ?: emptyList()
+}

--- a/application/src/main/kotlin/utils/filedialogs/Algorithms.kt
+++ b/application/src/main/kotlin/utils/filedialogs/Algorithms.kt
@@ -2,8 +2,17 @@ package utils.filedialogs
 
 import java.io.File
 
+/**
+ * Filters files within a given directory based on a provided filter function.
+ *
+ * @param directory the directory to filter files from
+ * @param filter a function that takes a [File] as input and returns a [Boolean]
+ * The function should return `true` for files that should be included in the result, and `false` otherwise.
+ *
+ * @return a list of files that satisfy the provided filter function.
+ * If the [directory] is not a valid directory or does not exist, an empty list is returned.
+ */
 fun filtrate(directory: File, filter: (File) -> Boolean): List<File> {
 	if (!directory.isDirectory || !directory.exists()) return emptyList()
-
 	return directory.listFiles()?.filter { filter(it) } ?: emptyList()
 }

--- a/application/src/main/kotlin/utils/filedialogs/Dialogs.kt
+++ b/application/src/main/kotlin/utils/filedialogs/Dialogs.kt
@@ -40,6 +40,20 @@ import themes.JetTheme
 import themes.sizeBottom
 import java.io.File
 
+/**
+ * A composable function that displays a dialog window for selecting a file or directory.
+ *
+ * @param isOpen a boolean indicating whether the dialog is open or closed
+ * @param icon the painter for the icon displayed in the dialog window
+ * @param title the title of the dialog window
+ * @param initDirectory the initial directory to display when the dialog is opened
+ * @param onCloseRequest a lambda function to be called when the dialog is closed
+ * @param onChooseItem an optional lambda function to be called when an item (file or directory) is chosen.
+ *                      It takes two parameters: the chosen directory and the chosen file (or null if a file isn't chosen).
+ *                      It should return a boolean indicating whether the dialog should be closed after the item is chosen
+ * @param filter an optional lambda function to filter the items displayed in the dialog.
+ *               It takes a File as a parameter and returns a boolean indicating whether the item should be displayed.
+ */
 @Composable
 fun PickerDialog(
 	isOpen: Boolean,
@@ -94,7 +108,7 @@ fun PickerDialog(
 				}
 				IconButton(
 					onClick = {
-						if (currentDirectory.parentFile!= null) {
+						if (currentDirectory.parentFile != null) {
 							currentDirectory = currentDirectory.parentFile
 							currentFile = null
 						}
@@ -110,7 +124,8 @@ fun PickerDialog(
 				}
 				OutlinedTextField(
 					value = currentDirectory.absolutePath,
-					onValueChange = { _ ->  },
+					onValueChange = { _ ->
+					},
 					readOnly = true,
 					modifier = Modifier.weight(6f),
 					singleLine = true,
@@ -147,7 +162,7 @@ fun PickerDialog(
 					)
 				}
 			}
-			Row (
+			Row(
 				modifier = Modifier.weight(1f),
 				verticalAlignment = Alignment.CenterVertically,
 				horizontalArrangement = Arrangement.spacedBy(4.dp)
@@ -186,6 +201,19 @@ fun PickerDialog(
 	}
 }
 
+/**
+ * A composable function that displays a dialog window for selecting a directory.
+ * It is a wrapper around the [PickerDialog] function, with a default icon for directory selection.
+ *
+ * @param isOpen a boolean indicating whether the dialog is open or closed
+ * @param title the title of the dialog window. Default value is "Directory Picker"
+ * @param initDirectory the initial directory to display when the dialog is opened
+ * @param onCloseRequest a lambda function to be called when the dialog is closed
+ * @param onChooseDirectory an optional lambda function to be called when a directory is chosen.
+ *                          It takes a single parameter: the chosen directory.
+ *                          It should return a boolean indicating whether the dialog should be closed after the directory is chosen.
+ *                          Default value is null, meaning no action is taken when a directory is chosen
+ */
 @Composable
 fun DirectoryPickerDialog(
 	isOpen: Boolean,
@@ -208,6 +236,22 @@ fun DirectoryPickerDialog(
 	)
 }
 
+/**
+ * A composable function that displays a dialog window for selecting a file.
+ * It is a wrapper around the [PickerDialog] function, with a default icon for file selection.
+ *
+ * @param isOpen a boolean indicating whether the dialog is open or closed
+ * @param title the title of the dialog window. Default value is "Directory Picker"
+ * @param initDirectory the initial directory to display when the dialog is opened
+ * @param onCloseRequest a lambda function to be called when the dialog is closed
+ * @param onChooseFile an optional lambda function to be called when a file is chosen.
+ *                     It takes a single parameter: the chosen file.
+ *                     It should return a boolean indicating whether the dialog should be closed after the file is chosen.
+ *                     Default value is null, meaning no action is taken when a file is chosen
+ * @param fileExtension a list of regular expressions representing the allowed file extensions.
+ *                      Only files with names matching any of the provided regular expressions will be displayed.
+ *                      Default value is an empty list, meaning all files will be displayed
+ */
 @Composable
 fun FilePickerDialog(
 	isOpen: Boolean,
@@ -227,7 +271,7 @@ fun FilePickerDialog(
 			if (currentFile == null) {
 				false
 			} else if (onChooseFile != null) {
-				onChooseFile(currentFile);
+				onChooseFile(currentFile)
 				true
 			} else {
 				true

--- a/application/src/main/kotlin/utils/filedialogs/Dialogs.kt
+++ b/application/src/main/kotlin/utils/filedialogs/Dialogs.kt
@@ -1,14 +1,20 @@
 package utils.filedialogs
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
+import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowLeft
 import androidx.compose.material.icons.filled.FileOpen
@@ -21,6 +27,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.text.style.TextAlign
@@ -29,6 +36,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogState
 import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.WindowPosition
+import themes.JetTheme
+import themes.sizeBottom
 import java.io.File
 
 @Composable
@@ -49,26 +58,39 @@ fun PickerDialog(
 		title = title,
 		state = DialogState(
 			position = WindowPosition(Alignment.Center),
-			size = DpSize(900.dp, 700.dp)
+			size = DpSize(1024.dp, 720.dp)
 		),
 		icon = icon
 	) {
 		Column(
-			modifier = Modifier.fillMaxSize(),
+			modifier = Modifier
+				.fillMaxSize()
+				.background(JetTheme.colors.primaryBackground)
+				.padding(4.dp),
 			horizontalAlignment = Alignment.CenterHorizontally
 		) {
 			Row(
 				modifier = Modifier.weight(1f),
 				verticalAlignment = Alignment.CenterVertically
 			) {
-				Icon(icon, title, modifier = Modifier.weight(0.5f))
+				Icon(
+					icon,
+					title,
+					modifier = Modifier.weight(0.5f).size(sizeBottom).clip(JetTheme.shapes.cornerStyle),
+					tint = JetTheme.colors.tintColor
+				)
 				IconButton(
 					onClick = {
 						currentDirectory = File(System.getProperty("user.home"))
 					},
 					modifier = Modifier.weight(0.5f)
 				) {
-					Icon(Icons.Filled.Home, "Home")
+					Icon(
+						Icons.Filled.Home,
+						"Home",
+						modifier = Modifier.size(sizeBottom).clip(JetTheme.shapes.cornerStyle),
+						tint = JetTheme.colors.tintColor
+					)
 				}
 				IconButton(
 					onClick = {
@@ -79,18 +101,31 @@ fun PickerDialog(
 					},
 					modifier = Modifier.weight(0.5f)
 				) {
-					Icon(Icons.Filled.ArrowLeft, "Back")
+					Icon(
+						Icons.Filled.ArrowLeft,
+						"Back",
+						modifier = Modifier.size(sizeBottom).clip(JetTheme.shapes.cornerStyle),
+						tint = JetTheme.colors.tintColor
+					)
 				}
 				OutlinedTextField(
 					value = currentDirectory.absolutePath,
 					onValueChange = { _ ->  },
 					readOnly = true,
-					modifier = Modifier.weight(6f)
+					modifier = Modifier.weight(6f),
+					singleLine = true,
+					colors = TextFieldDefaults.textFieldColors(
+						focusedIndicatorColor = JetTheme.colors.secondaryText,
+						focusedLabelColor = JetTheme.colors.secondaryText,
+						cursorColor = JetTheme.colors.tintColor
+					),
+					textStyle = JetTheme.typography.toolbar.copy(textAlign = TextAlign.Left)
 				)
 			}
 			Row(
 				modifier = Modifier.weight(8f),
-				verticalAlignment = Alignment.CenterVertically
+				verticalAlignment = Alignment.CenterVertically,
+				horizontalArrangement = Arrangement.spacedBy(4.dp)
 			) {
 				DirectoryContent(
 					modifier = Modifier.weight(2f),
@@ -114,12 +149,19 @@ fun PickerDialog(
 			}
 			Row (
 				modifier = Modifier.weight(1f),
-				verticalAlignment = Alignment.CenterVertically
+				verticalAlignment = Alignment.CenterVertically,
+				horizontalArrangement = Arrangement.spacedBy(4.dp)
 			) {
 				Spacer(Modifier.weight(4f))
 				TextButton(
 					modifier = Modifier.weight(1f),
-					onClick = { onCloseRequest() }
+					onClick = onCloseRequest,
+					colors = ButtonDefaults.buttonColors(
+						backgroundColor = JetTheme.colors.tertiaryBackground,
+						contentColor = JetTheme.colors.secondaryText,
+						disabledContentColor = JetTheme.colors.secondaryText,
+						disabledBackgroundColor = JetTheme.colors.tertiaryBackground
+					),
 				) {
 					Text("Cancel", textAlign = TextAlign.Center)
 				}
@@ -129,7 +171,13 @@ fun PickerDialog(
 						var isClose = true
 						if (onChooseItem != null) isClose = onChooseItem(currentDirectory, currentFile)
 						if (isClose) onCloseRequest()
-					}
+					},
+					colors = ButtonDefaults.buttonColors(
+						backgroundColor = JetTheme.colors.tertiaryBackground,
+						contentColor = JetTheme.colors.secondaryText,
+						disabledContentColor = JetTheme.colors.secondaryText,
+						disabledBackgroundColor = JetTheme.colors.tertiaryBackground
+					),
 				) {
 					Text("Open", textAlign = TextAlign.Center)
 				}

--- a/application/src/main/kotlin/utils/filedialogs/Dialogs.kt
+++ b/application/src/main/kotlin/utils/filedialogs/Dialogs.kt
@@ -1,0 +1,194 @@
+package utils.filedialogs
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowLeft
+import androidx.compose.material.icons.filled.FileOpen
+import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogState
+import androidx.compose.ui.window.DialogWindow
+import androidx.compose.ui.window.WindowPosition
+import java.io.File
+
+@Composable
+fun PickerDialog(
+	isOpen: Boolean,
+	icon: Painter,
+	title: String,
+	initDirectory: File,
+	onCloseRequest: (() -> Unit),
+	onChooseItem: ((File, File?) -> Boolean)? = null,
+	filter: (File) -> Boolean = { true }
+) {
+	var currentDirectory by remember { mutableStateOf(initDirectory) }
+	var currentFile by remember { mutableStateOf<File?>(null) }
+	DialogWindow(
+		visible = isOpen,
+		onCloseRequest = onCloseRequest,
+		title = title,
+		state = DialogState(
+			position = WindowPosition(Alignment.Center),
+			size = DpSize(900.dp, 700.dp)
+		),
+		icon = icon
+	) {
+		Column(
+			modifier = Modifier.fillMaxSize(),
+			horizontalAlignment = Alignment.CenterHorizontally
+		) {
+			Row(
+				modifier = Modifier.weight(1f),
+				verticalAlignment = Alignment.CenterVertically
+			) {
+				Icon(icon, title, modifier = Modifier.weight(0.5f))
+				IconButton(
+					onClick = {
+						currentDirectory = File(System.getProperty("user.home"))
+					},
+					modifier = Modifier.weight(0.5f)
+				) {
+					Icon(Icons.Filled.Home, "Home")
+				}
+				IconButton(
+					onClick = {
+						if (currentDirectory.parentFile!= null) {
+							currentDirectory = currentDirectory.parentFile
+							currentFile = null
+						}
+					},
+					modifier = Modifier.weight(0.5f)
+				) {
+					Icon(Icons.Filled.ArrowLeft, "Back")
+				}
+				OutlinedTextField(
+					value = currentDirectory.absolutePath,
+					onValueChange = { _ ->  },
+					readOnly = true,
+					modifier = Modifier.weight(6f)
+				)
+			}
+			Row(
+				modifier = Modifier.weight(8f),
+				verticalAlignment = Alignment.CenterVertically
+			) {
+				DirectoryContent(
+					modifier = Modifier.weight(2f),
+					currentDirectory,
+					onItemClick = { file ->
+						if (file.isFile) {
+							currentFile = file
+						} else if (file.isDirectory) {
+							currentDirectory = file
+							currentFile = null
+						}
+					},
+					filter
+				)
+				currentFile?.let { file ->
+					FileContent(
+						modifier = Modifier.weight(1f),
+						file
+					)
+				}
+			}
+			Row (
+				modifier = Modifier.weight(1f),
+				verticalAlignment = Alignment.CenterVertically
+			) {
+				Spacer(Modifier.weight(4f))
+				TextButton(
+					modifier = Modifier.weight(1f),
+					onClick = { onCloseRequest() }
+				) {
+					Text("Cancel", textAlign = TextAlign.Center)
+				}
+				TextButton(
+					modifier = Modifier.weight(1f),
+					onClick = {
+						var isClose = true
+						if (onChooseItem != null) isClose = onChooseItem(currentDirectory, currentFile)
+						if (isClose) onCloseRequest()
+					}
+				) {
+					Text("Open", textAlign = TextAlign.Center)
+				}
+			}
+		}
+	}
+}
+
+@Composable
+fun DirectoryPickerDialog(
+	isOpen: Boolean,
+	title: String = "Directory Picker",
+	initDirectory: File,
+	onCloseRequest: (() -> Unit),
+	onChooseDirectory: ((File) -> Unit)? = null,
+) {
+	PickerDialog(
+		isOpen,
+		rememberVectorPainter(Icons.Filled.FolderOpen),
+		title,
+		initDirectory,
+		onCloseRequest,
+		onChooseItem = { currentDirectory, _ ->
+			if (onChooseDirectory != null) onChooseDirectory(currentDirectory)
+			true
+		},
+		filter = { item -> item.isDirectory }
+	)
+}
+
+@Composable
+fun FilePickerDialog(
+	isOpen: Boolean,
+	title: String = "Directory Picker",
+	initDirectory: File,
+	onCloseRequest: (() -> Unit),
+	onChooseFile: ((File) -> Unit)? = null,
+	fileExtension: List<Regex> = listOf()
+) {
+	PickerDialog(
+		isOpen,
+		rememberVectorPainter(Icons.Filled.FileOpen),
+		title,
+		initDirectory,
+		onCloseRequest,
+		onChooseItem = { _, currentFile ->
+			if (currentFile == null) {
+				false
+			} else if (onChooseFile != null) {
+				onChooseFile(currentFile);
+				true
+			} else {
+				true
+			}
+		},
+		filter = { item ->
+			item.isDirectory || (
+				item.isFile && fileExtension.all { regex: Regex -> regex.matches(item.name) }
+			)
+		}
+	)
+}

--- a/application/src/main/kotlin/utils/filedialogs/Widgets.kt
+++ b/application/src/main/kotlin/utils/filedialogs/Widgets.kt
@@ -39,6 +39,12 @@ import java.io.File
 import java.io.FileReader
 import java.util.Date
 
+/**
+ * This function is used to display an empty content screen with a specified message and an icon.
+ *
+ * @param modifier the modifier to be applied to the layout
+ * @param message the message to be displayed on the screen. Default value is "Can't open content"
+ */
 @Composable
 fun EmptyContent(
 	modifier: Modifier = Modifier,
@@ -49,72 +55,90 @@ fun EmptyContent(
 	}
 }
 
+/**
+ * This function is used to display an empty content screen with a specified message and an icon.
+ *
+ * @param modifier the modifier to be applied to the layout
+ * @param message the message to be displayed on the screen. Default value is "Can't open content"
+ */
 @Composable
 fun FileContent(
 	modifier: Modifier = Modifier,
 	file: File
 ) {
-	if (!file.isFile) EmptyContent(
-		modifier,
-		"Can't open content of ${file.absolutePath}"
-	)
-	if (!file.exists()) EmptyContent(
-		modifier,
-		"File ${file.absolutePath} not exists"
-	)
-	Column(
-		modifier.border(0.5.dp, Color.Black, RectangleShape).padding(0.25.dp),
-		verticalArrangement = Arrangement.spacedBy(2.dp)
-	) {
+	if (!file.isFile) {
+		EmptyContent(
+			modifier,
+			"Can't open content of ${file.absolutePath}"
+		)
+	} else if (!file.exists()) {
+		EmptyContent(
+			modifier,
+			"File ${file.absolutePath} not exists"
+		)
+	} else {
 		Column(
-			modifier = Modifier.border(0.5.dp, Color.Black, RectangleShape).padding(0.25.dp),
-			verticalArrangement = Arrangement.spacedBy(2.dp),
-			horizontalAlignment = Alignment.CenterHorizontally
+			modifier.border(0.5.dp, Color.Black, RectangleShape).padding(0.25.dp),
+			verticalArrangement = Arrangement.spacedBy(2.dp)
 		) {
-			Text(
-				"File info",
-				modifier = Modifier.fillMaxWidth(),
-				textAlign = TextAlign.Center,
-				style = JetTheme.typography.body,
-				color = JetTheme.colors.secondaryText
-			)
-			listOf(
-				"Name: ${file.name}",
-				"Last Modified: ${Date(file.lastModified()).toLocaleString()}",
-				"Size: ${file.length()} bytes"
-			).forEach { text ->
+			Column(
+				modifier = Modifier.border(0.5.dp, Color.Black, RectangleShape).padding(0.25.dp),
+				verticalArrangement = Arrangement.spacedBy(2.dp),
+				horizontalAlignment = Alignment.CenterHorizontally
+			) {
 				Text(
-					text,
-					modifier = Modifier.fillMaxWidth().padding(8.dp),
-					textAlign = TextAlign.Left,
-					style = JetTheme.typography.mini.copy(fontSize = JetTheme.typography.mini.fontSize / 1.15),
+					"File info",
+					modifier = Modifier.fillMaxWidth(),
+					textAlign = TextAlign.Center,
+					style = JetTheme.typography.body,
 					color = JetTheme.colors.secondaryText
 				)
-			}
-		}
-		Box {
-			LazyColumn(
-				modifier = Modifier.fillMaxSize().align(Alignment.TopCenter),
-				horizontalAlignment = Alignment.Start
-			) {
-				item {
-
-				}
-				item {
-					val reader = BufferedReader(FileReader(file))
+				listOf(
+					"Name: ${file.name}",
+					"Last Modified: ${Date(file.lastModified()).toLocaleString()}",
+					"Size: ${file.length()} bytes"
+				).forEach { text ->
 					Text(
-						modifier = modifier.padding(8.dp),
-						text = reader.use { it.readText() },
-						style = JetTheme.typography.toolbar,
+						text,
+						modifier = Modifier.fillMaxWidth().padding(8.dp),
+						textAlign = TextAlign.Left,
+						style = JetTheme.typography.mini.copy(fontSize = JetTheme.typography.mini.fontSize / 1.15),
 						color = JetTheme.colors.secondaryText
 					)
-					reader.close()
+				}
+			}
+			Box {
+				LazyColumn(
+					modifier = Modifier.fillMaxSize().align(Alignment.TopCenter),
+					horizontalAlignment = Alignment.Start
+				) {
+					item {
+						val reader = BufferedReader(FileReader(file))
+						Text(
+							modifier = modifier.padding(8.dp),
+							text = reader.use { it.readText() },
+							style = JetTheme.typography.toolbar,
+							color = JetTheme.colors.secondaryText
+						)
+						reader.close()
+					}
 				}
 			}
 		}
 	}
 }
 
+/**
+ * This function is used to display the contents of a directory in a structured layout.
+ * It provides a list of files and directories within the specified directory, and allows for
+ * interaction with each item through the [onItemClick] callback.
+ *
+ * @param modifier the modifier to be applied to the layout
+ * @param directory the directory to be displayed
+ * @param onItemClick a callback function that is invoked when an item (file or directory) is clicked.
+ * The clicked item is passed as a parameter to this function.
+ * @param filter a function that filters the items to be displayed. By default, all items are displayed.
+ */
 @Composable
 fun DirectoryContent(
 	modifier: Modifier = Modifier,
@@ -122,83 +146,86 @@ fun DirectoryContent(
 	onItemClick: ((File) -> (Unit)) = { file -> println("Click on ${file.absolutePath}") },
 	filter: (File) -> Boolean = { true }
 ) {
-	if (!directory.isDirectory) EmptyContent(
-		modifier,
-		"Can't open content of ${directory.absolutePath}"
-	)
-	if (!directory.exists()) EmptyContent(
-		modifier,
-		"File ${directory.absolutePath} not exists"
-	)
-	var chosenFile by remember { mutableStateOf<File?>(null) }
-	Box(
-		modifier
-	) {
-		LazyColumn(
-			modifier = Modifier.fillMaxSize().align(Alignment.TopCenter),
-			horizontalAlignment = Alignment.Start,
-			verticalArrangement = Arrangement.spacedBy(2.dp)
+	if (!directory.isDirectory) {
+		EmptyContent(
+			modifier,
+			"Can't open content of ${directory.absolutePath}"
+		)
+	} else if (!directory.exists()) {
+		EmptyContent(
+			modifier,
+			"File ${directory.absolutePath} not exists"
+		)
+	} else {
+		var chosenFile by remember { mutableStateOf<File?>(null) }
+		Box(
+			modifier
 		) {
-			val dirItems = filtrate(directory, filter)
-			items(dirItems.filter { it.isDirectory }.sorted()) { item ->
-				Row(
-					modifier = Modifier.border(0.5.dp, Color.Black, RectangleShape),
-					verticalAlignment = Alignment.CenterVertically
-				) {
-					Icon(
-						imageVector = if (item.isDirectory) Icons.Filled.Folder else Icons.Filled.FilePresent,
-						contentDescription = if (item.isDirectory) "Directory" else "File",
-						modifier = Modifier.weight(0.5f).size(sizeBottom).clip(JetTheme.shapes.cornerStyle),
-						tint = JetTheme.colors.tintColor
-					)
-					TextButton(
-						onClick = {
-							chosenFile = if (!item.isFile) null else item
-							onItemClick(item)
-						},
-						colors = ButtonDefaults.buttonColors(
-							backgroundColor = JetTheme.colors.primaryBackground,
-							contentColor = JetTheme.colors.secondaryText,
-							disabledContentColor = JetTheme.colors.secondaryText,
-							disabledBackgroundColor = JetTheme.colors.tertiaryBackground
-						),
-						modifier = Modifier.weight(4.5f).padding(5.dp, 5.dp),
+			LazyColumn(
+				modifier = Modifier.fillMaxSize().align(Alignment.TopCenter),
+				horizontalAlignment = Alignment.Start,
+				verticalArrangement = Arrangement.spacedBy(2.dp)
+			) {
+				val dirItems = filtrate(directory, filter)
+				items(dirItems.filter { it.isDirectory }.sorted()) { item ->
+					Row(
+						modifier = Modifier.border(0.5.dp, Color.Black, RectangleShape),
+						verticalAlignment = Alignment.CenterVertically
 					) {
-						Text(item.absolutePath)
+						Icon(
+							imageVector = if (item.isDirectory) Icons.Filled.Folder else Icons.Filled.FilePresent,
+							contentDescription = if (item.isDirectory) "Directory" else "File",
+							modifier = Modifier.weight(0.5f).size(sizeBottom).clip(JetTheme.shapes.cornerStyle),
+							tint = JetTheme.colors.tintColor
+						)
+						TextButton(
+							onClick = {
+								chosenFile = if (!item.isFile) null else item
+								onItemClick(item)
+							},
+							colors = ButtonDefaults.buttonColors(
+								backgroundColor = JetTheme.colors.primaryBackground,
+								contentColor = JetTheme.colors.secondaryText,
+								disabledContentColor = JetTheme.colors.secondaryText,
+								disabledBackgroundColor = JetTheme.colors.tertiaryBackground
+							),
+							modifier = Modifier.weight(4.5f).padding(5.dp, 5.dp),
+						) {
+							Text(item.absolutePath)
+						}
 					}
 				}
-			}
-			items(dirItems.filter { it.isFile }.sorted()) { item ->
-				val isChosenItem = chosenFile == item
-				val itemModifier = if (isChosenItem) Modifier.background(Color.Gray) else Modifier
-				Row(
-					modifier = itemModifier.fillMaxWidth().border(0.5.dp, Color.Black, RectangleShape),
-					verticalAlignment = Alignment.CenterVertically
-				) {
-					Icon(
-						imageVector = if (item.isDirectory) Icons.Filled.Folder else Icons.Filled.FilePresent,
-						contentDescription = if (item.isDirectory) "Directory" else "File",
-						modifier = Modifier.weight(0.5f).size(sizeBottom).clip(JetTheme.shapes.cornerStyle),
-						tint = JetTheme.colors.tintColor
-					)
-					TextButton(
-						onClick = {
-							chosenFile = if (!item.isFile) null else item
-							onItemClick(item)
-						},
-						colors = ButtonDefaults.buttonColors(
-							backgroundColor = JetTheme.colors.primaryBackground,
-							contentColor = JetTheme.colors.secondaryText,
-							disabledContentColor = JetTheme.colors.secondaryText,
-							disabledBackgroundColor = JetTheme.colors.tertiaryBackground
-						),
-						modifier = Modifier.weight(4.5f).padding(5.dp, 5.dp),
+				items(dirItems.filter { it.isFile }.sorted()) { item ->
+					val isChosenItem = chosenFile == item
+					val itemModifier = if (isChosenItem) Modifier.background(Color.Gray) else Modifier
+					Row(
+						modifier = itemModifier.fillMaxWidth().border(0.5.dp, Color.Black, RectangleShape),
+						verticalAlignment = Alignment.CenterVertically
 					) {
-						Text(item.absolutePath)
+						Icon(
+							imageVector = if (item.isDirectory) Icons.Filled.Folder else Icons.Filled.FilePresent,
+							contentDescription = if (item.isDirectory) "Directory" else "File",
+							modifier = Modifier.weight(0.5f).size(sizeBottom).clip(JetTheme.shapes.cornerStyle),
+							tint = JetTheme.colors.tintColor
+						)
+						TextButton(
+							onClick = {
+								chosenFile = if (!item.isFile) null else item
+								onItemClick(item)
+							},
+							colors = ButtonDefaults.buttonColors(
+								backgroundColor = JetTheme.colors.primaryBackground,
+								contentColor = JetTheme.colors.secondaryText,
+								disabledContentColor = JetTheme.colors.secondaryText,
+								disabledBackgroundColor = JetTheme.colors.tertiaryBackground
+							),
+							modifier = Modifier.weight(4.5f).padding(5.dp, 5.dp),
+						) {
+							Text(item.absolutePath)
+						}
 					}
 				}
 			}
 		}
-
 	}
 }

--- a/application/src/main/kotlin/utils/filedialogs/Widgets.kt
+++ b/application/src/main/kotlin/utils/filedialogs/Widgets.kt
@@ -1,0 +1,148 @@
+package utils.filedialogs
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FilePresent
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.NotAccessible
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import java.io.BufferedReader
+import java.io.File
+import java.io.FileReader
+
+@Composable
+fun EmptyContent(
+	modifier: Modifier = Modifier,
+	message: String = "Can't open content"
+) {
+	Column(modifier) {
+		Icon(Icons.Filled.NotAccessible, message)
+	}
+}
+
+@Composable
+fun FileContent(
+	modifier: Modifier = Modifier,
+	file: File
+) {
+	if (!file.isFile) EmptyContent(
+		modifier,
+		"Can't open content of ${file.absolutePath}"
+	)
+	if (!file.exists()) EmptyContent(
+		modifier,
+		"File ${file.absolutePath} not exists"
+	)
+	Box(modifier.border(0.5.dp, Color.Black, RectangleShape).padding(0.25.dp)) {
+		LazyColumn(
+			modifier = Modifier.fillMaxSize().align(Alignment.TopCenter),
+			horizontalAlignment = Alignment.Start
+		) {
+			item {
+				val reader = BufferedReader(FileReader(file))
+				Text(
+					modifier = modifier.padding(8.dp),
+					text = reader.use { it.readText() }
+				)
+				reader.close()
+			}
+		}
+	}
+}
+
+@Composable
+fun DirectoryContent(
+	modifier: Modifier = Modifier,
+	directory: File,
+	onItemClick: ((File) -> (Unit)) = { file -> println("Click on ${file.absolutePath}") },
+	filter: (File) -> Boolean = { true }
+) {
+	if (!directory.isDirectory) EmptyContent(
+		modifier,
+		"Can't open content of ${directory.absolutePath}"
+	)
+	if (!directory.exists()) EmptyContent(
+		modifier,
+		"File ${directory.absolutePath} not exists"
+	)
+	var chosenFile by remember { mutableStateOf<File?>(null) }
+	Box(
+		modifier
+	) {
+		LazyColumn(
+			modifier = Modifier.fillMaxSize().align(Alignment.TopCenter),
+			horizontalAlignment = Alignment.Start,
+			verticalArrangement = Arrangement.spacedBy(2.dp)
+		) {
+			val dirItems = filtrate(directory, filter)
+			items(dirItems.filter { it.isDirectory }.sorted()) { item ->
+				Row(
+					modifier = Modifier.border(0.5.dp, Color.Black, RectangleShape),
+					verticalAlignment = Alignment.CenterVertically
+				) {
+					Icon(
+						imageVector = if (item.isDirectory) Icons.Filled.Folder else Icons.Filled.FilePresent,
+						contentDescription = if (item.isDirectory) "Directory" else "File",
+						modifier = Modifier.weight(0.5f)
+					)
+					TextButton(
+						onClick = {
+							chosenFile = if (!item.isFile) null else item
+							onItemClick(item)
+						},
+						modifier = Modifier.weight(4.5f)
+					) {
+						Text(item.absolutePath, textAlign = TextAlign.Left)
+					}
+				}
+			}
+			items(dirItems.filter { it.isFile }.sorted()) { item ->
+				val isChosenItem = chosenFile == item
+				val itemModifier = if (isChosenItem) Modifier.background(Color.Gray) else Modifier
+				Row(
+					modifier = itemModifier.fillMaxWidth().border(0.5.dp, Color.Black, RectangleShape),
+					verticalAlignment = Alignment.CenterVertically
+				) {
+					Icon(
+						imageVector = if (item.isDirectory) Icons.Filled.Folder else Icons.Filled.FilePresent,
+						contentDescription = if (item.isDirectory) "Directory" else "File",
+						modifier = Modifier.weight(0.5f)
+					)
+					TextButton(
+						onClick = {
+							chosenFile = if (!item.isFile) null else item
+							onItemClick(item)
+						},
+						modifier = Modifier.weight(4.5f)
+					) {
+						Text(item.absolutePath, textAlign = TextAlign.Left)
+					}
+				}
+			}
+		}
+
+	}
+}

--- a/application/src/main/kotlin/utils/filedialogs/Widgets.kt
+++ b/application/src/main/kotlin/utils/filedialogs/Widgets.kt
@@ -37,7 +37,6 @@ import themes.sizeBottom
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
-import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.util.*
 

--- a/application/src/main/kotlin/utils/filedialogs/Widgets.kt
+++ b/application/src/main/kotlin/utils/filedialogs/Widgets.kt
@@ -9,8 +9,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
@@ -25,13 +27,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import themes.JetTheme
+import themes.sizeBottom
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
+import java.util.Date
 
 @Composable
 fun EmptyContent(
@@ -56,18 +62,54 @@ fun FileContent(
 		modifier,
 		"File ${file.absolutePath} not exists"
 	)
-	Box(modifier.border(0.5.dp, Color.Black, RectangleShape).padding(0.25.dp)) {
-		LazyColumn(
-			modifier = Modifier.fillMaxSize().align(Alignment.TopCenter),
-			horizontalAlignment = Alignment.Start
+	Column(
+		modifier.border(0.5.dp, Color.Black, RectangleShape).padding(0.25.dp),
+		verticalArrangement = Arrangement.spacedBy(2.dp)
+	) {
+		Column(
+			modifier = Modifier.border(0.5.dp, Color.Black, RectangleShape).padding(0.25.dp),
+			verticalArrangement = Arrangement.spacedBy(2.dp),
+			horizontalAlignment = Alignment.CenterHorizontally
 		) {
-			item {
-				val reader = BufferedReader(FileReader(file))
+			Text(
+				"File info",
+				modifier = Modifier.fillMaxWidth(),
+				textAlign = TextAlign.Center,
+				style = JetTheme.typography.body,
+				color = JetTheme.colors.secondaryText
+			)
+			listOf(
+				"Name: ${file.name}",
+				"Last Modified: ${Date(file.lastModified()).toLocaleString()}",
+				"Size: ${file.length()} bytes"
+			).forEach { text ->
 				Text(
-					modifier = modifier.padding(8.dp),
-					text = reader.use { it.readText() }
+					text,
+					modifier = Modifier.fillMaxWidth().padding(8.dp),
+					textAlign = TextAlign.Left,
+					style = JetTheme.typography.mini.copy(fontSize = JetTheme.typography.mini.fontSize / 1.15),
+					color = JetTheme.colors.secondaryText
 				)
-				reader.close()
+			}
+		}
+		Box {
+			LazyColumn(
+				modifier = Modifier.fillMaxSize().align(Alignment.TopCenter),
+				horizontalAlignment = Alignment.Start
+			) {
+				item {
+
+				}
+				item {
+					val reader = BufferedReader(FileReader(file))
+					Text(
+						modifier = modifier.padding(8.dp),
+						text = reader.use { it.readText() },
+						style = JetTheme.typography.toolbar,
+						color = JetTheme.colors.secondaryText
+					)
+					reader.close()
+				}
 			}
 		}
 	}
@@ -106,16 +148,23 @@ fun DirectoryContent(
 					Icon(
 						imageVector = if (item.isDirectory) Icons.Filled.Folder else Icons.Filled.FilePresent,
 						contentDescription = if (item.isDirectory) "Directory" else "File",
-						modifier = Modifier.weight(0.5f)
+						modifier = Modifier.weight(0.5f).size(sizeBottom).clip(JetTheme.shapes.cornerStyle),
+						tint = JetTheme.colors.tintColor
 					)
 					TextButton(
 						onClick = {
 							chosenFile = if (!item.isFile) null else item
 							onItemClick(item)
 						},
-						modifier = Modifier.weight(4.5f)
+						colors = ButtonDefaults.buttonColors(
+							backgroundColor = JetTheme.colors.primaryBackground,
+							contentColor = JetTheme.colors.secondaryText,
+							disabledContentColor = JetTheme.colors.secondaryText,
+							disabledBackgroundColor = JetTheme.colors.tertiaryBackground
+						),
+						modifier = Modifier.weight(4.5f).padding(5.dp, 5.dp),
 					) {
-						Text(item.absolutePath, textAlign = TextAlign.Left)
+						Text(item.absolutePath)
 					}
 				}
 			}
@@ -129,16 +178,23 @@ fun DirectoryContent(
 					Icon(
 						imageVector = if (item.isDirectory) Icons.Filled.Folder else Icons.Filled.FilePresent,
 						contentDescription = if (item.isDirectory) "Directory" else "File",
-						modifier = Modifier.weight(0.5f)
+						modifier = Modifier.weight(0.5f).size(sizeBottom).clip(JetTheme.shapes.cornerStyle),
+						tint = JetTheme.colors.tintColor
 					)
 					TextButton(
 						onClick = {
 							chosenFile = if (!item.isFile) null else item
 							onItemClick(item)
 						},
-						modifier = Modifier.weight(4.5f)
+						colors = ButtonDefaults.buttonColors(
+							backgroundColor = JetTheme.colors.primaryBackground,
+							contentColor = JetTheme.colors.secondaryText,
+							disabledContentColor = JetTheme.colors.secondaryText,
+							disabledBackgroundColor = JetTheme.colors.tertiaryBackground
+						),
+						modifier = Modifier.weight(4.5f).padding(5.dp, 5.dp),
 					) {
-						Text(item.absolutePath, textAlign = TextAlign.Left)
+						Text(item.absolutePath)
 					}
 				}
 			}

--- a/application/src/main/kotlin/utils/filedialogs/Widgets.kt
+++ b/application/src/main/kotlin/utils/filedialogs/Widgets.kt
@@ -37,7 +37,9 @@ import themes.sizeBottom
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
-import java.util.Date
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+import java.util.*
 
 /**
  * This function is used to display an empty content screen with a specified message and an icon.
@@ -77,6 +79,7 @@ fun FileContent(
 			"File ${file.absolutePath} not exists"
 		)
 	} else {
+		val dateFormat = SimpleDateFormat("dd.MM.yyyy HH:mm:ss", Locale.getDefault())
 		Column(
 			modifier.border(0.5.dp, Color.Black, RectangleShape).padding(0.25.dp),
 			verticalArrangement = Arrangement.spacedBy(2.dp)
@@ -95,7 +98,7 @@ fun FileContent(
 				)
 				listOf(
 					"Name: ${file.name}",
-					"Last Modified: ${Date(file.lastModified()).toLocaleString()}",
+					"Last Modified: ${dateFormat.format(Date(file.lastModified()))}",
 					"Size: ${file.length()} bytes"
 				).forEach { text ->
 					Text(

--- a/application/src/main/kotlin/viewmodels/dialogs/CreateNewGraphDialogViewModel.kt
+++ b/application/src/main/kotlin/viewmodels/dialogs/CreateNewGraphDialogViewModel.kt
@@ -28,7 +28,6 @@ class CreateNewGraphDialogViewModel(val homePageViewModel: HomePageViewModel) {
 	private val sqliteSavingDirectory = File(
 		homePageViewModel.settings.applicationContextDirectory,
 		"sqlite-dbs"
-
 	)
 	val graphName = mutableStateOf("")
 	val selectedVertexTypeID = mutableStateOf(VertexIDType.INT_TYPE)

--- a/application/src/main/kotlin/viewmodels/dialogs/LoadNewGraphDialogViewModel.kt
+++ b/application/src/main/kotlin/viewmodels/dialogs/LoadNewGraphDialogViewModel.kt
@@ -25,4 +25,10 @@ class LoadNewGraphDialogViewModel(val homePageViewModel: HomePageViewModel) {
 	val selectedLoadType = mutableStateOf(GraphSavingType.LOCAL_FILE)
 	val loadFile = mutableStateOf("")
 	val settings: SettingsModel = homePageViewModel.settings
+	val fileExtension: List<Regex>
+		get() {
+			val regex = selectedLoadType.value.filenamePatterns
+			if (regex != null) return listOf(regex)
+			else return listOf()
+		}
 }

--- a/application/src/main/kotlin/viewmodels/dialogs/LoadNewGraphDialogViewModel.kt
+++ b/application/src/main/kotlin/viewmodels/dialogs/LoadNewGraphDialogViewModel.kt
@@ -16,6 +16,7 @@ import viewmodels.pages.HomePageViewModel
  * @property selectedLoadType a MutableState of the selected graph load type
  * @property loadFile a MutableState of the file path to load the graph from
  * @property settings the settings of the application
+ * @property fileExtension a MutableState of the file extension
  */
 class LoadNewGraphDialogViewModel(val homePageViewModel: HomePageViewModel) {
 	var neo4jHost = mutableStateOf("")
@@ -27,8 +28,11 @@ class LoadNewGraphDialogViewModel(val homePageViewModel: HomePageViewModel) {
 	val settings: SettingsModel = homePageViewModel.settings
 	val fileExtension: List<Regex>
 		get() {
-			val regex = selectedLoadType.value.filenamePatterns
-			if (regex != null) return listOf(regex)
-			else return listOf()
+			val regex = selectedLoadType.value.filenamePattern
+			if (regex != null) {
+				return listOf(regex)
+			} else {
+				return listOf()
+			}
 		}
 }

--- a/application/src/main/kotlin/viewmodels/pages/HomePageViewModel.kt
+++ b/application/src/main/kotlin/viewmodels/pages/HomePageViewModel.kt
@@ -81,11 +81,7 @@ class HomePageViewModel(
 			) { isOpenDialogOfLoadingNewGraph = true }
 		)
 
-		val file = File("../history")
-		findOrCreateFile(file)
-		file.readLines().forEach {
-			loadGraphInfoFromString(it)
-		}
+		loadHistory()
 	}
 
 	/**
@@ -215,5 +211,13 @@ class HomePageViewModel(
 				}
 			)
 		)
+	}
+
+	private fun loadHistory() {
+		val file = File(settings.applicationContextDirectory, "/.history")
+		findOrCreateFile(file)
+		file.readLines().forEach {
+			loadGraphInfoFromString(it)
+		}
 	}
 }

--- a/application/src/main/kotlin/views/dialogs/CreateNewGraphDialog.kt
+++ b/application/src/main/kotlin/views/dialogs/CreateNewGraphDialog.kt
@@ -37,15 +37,16 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberDialogState
-import com.darkrockstudios.libraries.mpfilepicker.DirectoryPicker
 import kotlinx.coroutines.launch
 import themes.JetTheme
 import utils.ComboBox
 import utils.CustomRadioButton
 import utils.GraphSavingType
 import utils.VertexIDType
+import utils.filedialogs.DirectoryPickerDialog
+import utils.filedialogs.FilePickerDialog
+import utils.filedialogs.PickerDialog
 import viewmodels.dialogs.CreateNewGraphDialogViewModel
-import java.io.File
 
 /**
  * A composable function that creates a dialog window for creating a new graph.
@@ -295,16 +296,16 @@ fun CreateNewGraphDialog(viewModel: CreateNewGraphDialogViewModel) {
 				}
 			}
 		}
-		DirectoryPicker(
+		DirectoryPickerDialog(
 			isOpenFolderPickDialog,
-			initialDirectory = viewModel.saveFolder.value.absolutePath,
-			title = "Choose save directory"
-		) { path ->
-			isOpenFolderPickDialog = false
-			if (path != null) {
-				viewModel.isCustomSaveDirectory.value = true
-				viewModel.saveFolder.value = File(path)
+			"Choose directory",
+			viewModel.saveFolder.value,
+			onCloseRequest = { isOpenFolderPickDialog = false },
+			onChooseDirectory = { folder ->
+				if (folder.isDirectory && folder.exists()) {
+					viewModel.saveFolder.value = folder
+				}
 			}
-		}
+		)
 	}
 }

--- a/application/src/main/kotlin/views/dialogs/CreateNewGraphDialog.kt
+++ b/application/src/main/kotlin/views/dialogs/CreateNewGraphDialog.kt
@@ -45,6 +45,7 @@ import utils.CustomRadioButton
 import utils.GraphSavingType
 import utils.VertexIDType
 import viewmodels.dialogs.CreateNewGraphDialogViewModel
+import java.io.File
 
 /**
  * A composable function that creates a dialog window for creating a new graph.
@@ -142,7 +143,10 @@ fun CreateNewGraphDialog(viewModel: CreateNewGraphDialogViewModel) {
 				ComboBox(
 					items = GraphSavingType.entries.toTypedArray(),
 					modifier = Modifier.weight(1f),
-					onItemClick = { item: GraphSavingType -> viewModel.selectedSaveType.value = item },
+					onItemClick = { item: GraphSavingType ->
+						viewModel.selectedSaveType.value = item
+						viewModel.updateSaveFolder(item)
+					},
 					textAlign = TextAlign.Center
 				)
 			}
@@ -153,7 +157,7 @@ fun CreateNewGraphDialog(viewModel: CreateNewGraphDialogViewModel) {
 			) {
 				if (viewModel.selectedSaveType.value != GraphSavingType.NEO4J_DB) {
 					OutlinedTextField(
-						value = viewModel.saveFolder.value,
+						value = viewModel.saveFolder.value.absolutePath,
 						readOnly = true,
 						label = { Text("Folder path", style = JetTheme.typography.toolbar) },
 						onValueChange = {},
@@ -280,7 +284,7 @@ fun CreateNewGraphDialog(viewModel: CreateNewGraphDialogViewModel) {
 									viewModel.isGraphDirected.value,
 									viewModel.isGraphWeighted.value,
 									viewModel.selectedSaveType.value,
-									viewModel.saveFolder.value
+									viewModel.saveFolder.value.absolutePath
 								)
 							}
 							viewModel.homePageViewModel.isOpenDialogOfCreatingNewGraph = false
@@ -291,9 +295,16 @@ fun CreateNewGraphDialog(viewModel: CreateNewGraphDialogViewModel) {
 				}
 			}
 		}
-		DirectoryPicker(isOpenFolderPickDialog) { path ->
+		DirectoryPicker(
+			isOpenFolderPickDialog,
+			initialDirectory = viewModel.saveFolder.value.absolutePath,
+			title = "Choose save directory"
+		) { path ->
 			isOpenFolderPickDialog = false
-			if (path != null) viewModel.saveFolder.value = path
+			if (path != null) {
+				viewModel.isCustomSaveDirectory.value = true
+				viewModel.saveFolder.value = File(path)
+			}
 		}
 	}
 }

--- a/application/src/main/kotlin/views/dialogs/CreateNewGraphDialog.kt
+++ b/application/src/main/kotlin/views/dialogs/CreateNewGraphDialog.kt
@@ -44,8 +44,6 @@ import utils.CustomRadioButton
 import utils.GraphSavingType
 import utils.VertexIDType
 import utils.filedialogs.DirectoryPickerDialog
-import utils.filedialogs.FilePickerDialog
-import utils.filedialogs.PickerDialog
 import viewmodels.dialogs.CreateNewGraphDialogViewModel
 
 /**

--- a/application/src/main/kotlin/views/dialogs/LoadNewGraphDialog.kt
+++ b/application/src/main/kotlin/views/dialogs/LoadNewGraphDialog.kt
@@ -83,7 +83,7 @@ fun LoadNewGraphDialog(viewModel: LoadNewGraphDialogViewModel) {
 					OutlinedTextField(
 						value = viewModel.loadFile.value,
 						readOnly = true,
-						label = { Text("Folder path", style = JetTheme.typography.toolbar) },
+						label = { Text("File path", style = JetTheme.typography.toolbar) },
 						onValueChange = {},
 						modifier = Modifier.weight(1f),
 						singleLine = true,
@@ -231,7 +231,11 @@ fun LoadNewGraphDialog(viewModel: LoadNewGraphDialogViewModel) {
 				}
 			}
 		}
-		FilePicker(isOpenFilePickDialog) { selectedPath ->
+		FilePicker(
+			isOpenFilePickDialog,
+			initialDirectory = viewModel.settings.applicationContextDirectory.absolutePath,
+			title = "Load graph",
+		) { selectedPath ->
 			isOpenFilePickDialog = false
 			if (selectedPath != null) viewModel.loadFile.value = selectedPath.path
 		}

--- a/application/src/main/kotlin/views/dialogs/LoadNewGraphDialog.kt
+++ b/application/src/main/kotlin/views/dialogs/LoadNewGraphDialog.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.launch
 import themes.JetTheme
 import utils.ComboBox
 import utils.GraphSavingType
+import utils.filedialogs.FilePickerDialog
 import viewmodels.dialogs.LoadNewGraphDialogViewModel
 
 /**
@@ -231,13 +232,16 @@ fun LoadNewGraphDialog(viewModel: LoadNewGraphDialogViewModel) {
 				}
 			}
 		}
-		FilePicker(
+		FilePickerDialog(
 			isOpenFilePickDialog,
-			initialDirectory = viewModel.settings.applicationContextDirectory.absolutePath,
-			title = "Load graph",
-		) { selectedPath ->
-			isOpenFilePickDialog = false
-			if (selectedPath != null) viewModel.loadFile.value = selectedPath.path
-		}
+			"Load graph-info file",
+			initDirectory = viewModel.settings.applicationContextDirectory,
+			onCloseRequest = { isOpenFilePickDialog = false },
+			onChooseFile = { selectedPath ->
+				isOpenFilePickDialog = false
+				viewModel.loadFile.value = selectedPath.path
+			},
+			fileExtension = viewModel.fileExtension
+		)
 	}
 }

--- a/application/src/main/kotlin/views/dialogs/LoadNewGraphDialog.kt
+++ b/application/src/main/kotlin/views/dialogs/LoadNewGraphDialog.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberDialogState
-import com.darkrockstudios.libraries.mpfilepicker.FilePicker
 import kotlinx.coroutines.launch
 import themes.JetTheme
 import utils.ComboBox


### PR DESCRIPTION
Изменена система вызова диалогов выбора директории и файлов.
Вместо использования сторонней библиотеки: [`compose-multiplatform-file-picker`](https://github.com/Wavesonics/compose-multiplatform-file-picker) реализованы собственные диалоговые окна, через `@Composable` функции.

Новое представление окон:
![Снимок экрана от 2024-07-20 22-43-25](https://github.com/user-attachments/assets/b8bb023f-4b8d-475c-bae9-874646538fe0)
![Снимок экрана от 2024-07-20 22-36-02](https://github.com/user-attachments/assets/b397e2c4-0602-4087-a4a5-2a1412035112)



resolve #38