### PR TITLE
Add simplest integration test for application

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
 	kotlin("jvm") version "1.9.20"
-	id("org.jetbrains.compose") version "1.5.10"
+	id("org.jetbrains.compose") version "1.6.2"
 }
 
 repositories {
@@ -23,6 +23,24 @@ dependencies {
 	implementation("org.slf4j", "slf4j-simple", "1.7.29")
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.8.1")
+
+	testImplementation("org.jetbrains.kotlin:kotlin-test")
+	testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+	testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
+	testImplementation("io.mockk:mockk:1.13.11")
+
+	// JUnit 5
+	testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.2")
+	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")
+	testImplementation("org.junit.vintage:junit-vintage-engine:5.10.2")
+
+	// Compose UI Test
+	testImplementation("org.jetbrains.compose.ui:ui-test-junit4:1.6.2")
+
+	// Test Containers
+	testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
+	testImplementation("org.testcontainers:testcontainers:1.19.8")
+	testImplementation("org.testcontainers:junit-jupiter:1.19.8")
 }
 
 compose.desktop {

--- a/application/src/main/kotlin/Main.kt
+++ b/application/src/main/kotlin/Main.kt
@@ -1,5 +1,4 @@
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember

--- a/application/src/main/kotlin/Main.kt
+++ b/application/src/main/kotlin/Main.kt
@@ -62,7 +62,7 @@ fun main() {
 			LaunchedEffect(windowState.size) {
 				settings.actualWindowSize = windowState.size.toIntSize()
 			}
-			MaterialTheme { MainScreen(mainScreenViewModel, jetSettings) }
+			MainScreen(mainScreenViewModel, jetSettings)
 		}
 	}
 }

--- a/application/src/main/kotlin/views/SideMenu.kt
+++ b/application/src/main/kotlin/views/SideMenu.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import models.utils.TabItem
@@ -41,7 +42,9 @@ import viewmodels.SideMenuViewModel
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun SideMenu(statePager: PagerState, indexSelectedPage: MutableState<Int>, viewModel: SideMenuViewModel) {
-	Column(Modifier.width(sizeBottom).fillMaxHeight()) {
+	Column(
+		modifier = Modifier.width(sizeBottom).fillMaxHeight().testTag("side-menu")
+	) {
 		viewModel.tabsItems.forEach { tabsColumn ->
 			if (tabsColumn == null) {
 				Spacer(Modifier.weight(1f))
@@ -101,7 +104,8 @@ fun SideMenuTabColumn(
 							contentDescription = item.title,
 							tint = JetTheme.colors.tintColor
 						)
-					}
+					},
+					modifier = Modifier.testTag("side-menu-item#${item.title}")
 				)
 				val dropDownMenuContext = item.dropDownMenuContext
 				if (dropDownMenuContext != null && indexSelectedPage.value == 1) {

--- a/application/src/main/kotlin/views/pages/GraphViewPage.kt
+++ b/application/src/main/kotlin/views/pages/GraphViewPage.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
@@ -112,6 +113,7 @@ fun GraphViewPage(graphPageViewModel: GraphPageViewModel) {
 				.padding(paddingCustom)
 				.clip(JetTheme.shapes.cornerStyle)
 				.background(Color(175, 218, 252), JetTheme.shapes.cornerStyle)
+				.testTag("graph-view-page")
 		) {
 			GraphView(
 				graphViewModel,

--- a/application/src/main/kotlin/views/pages/HomePage.kt
+++ b/application/src/main/kotlin/views/pages/HomePage.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import themes.JetTheme
 import themes.paddingCustom
@@ -43,7 +44,9 @@ fun HomePage(viewModel: HomePageViewModel) {
 		.clip(JetTheme.shapes.cornerStyle)
 		.background(JetTheme.colors.primaryBackground, JetTheme.shapes.cornerStyle)
 
-	Row {
+	Row(
+		modifier = Modifier.testTag("home-page")
+	) {
 		LazyListWidget(
 			modifier = modifierColumn.weight(1f),
 			listItems = viewModel.previouslyLoadedGraph,

--- a/application/src/main/kotlin/views/pages/SettingsPage.kt
+++ b/application/src/main/kotlin/views/pages/SettingsPage.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import models.JetSettings
 import mu.KotlinLogging
@@ -66,6 +67,7 @@ fun SettingsPage(jetSettings: JetSettings) {
 			.background(JetTheme.colors.primaryBackground)
 			.fillMaxSize()
 			.verticalScroll(rememberScrollState())
+			.testTag("settings-page")
 	) {
 		Row(
 			modifier = Modifier

--- a/application/src/test/kotlin/integrations/TestApplicationInitialization.kt
+++ b/application/src/test/kotlin/integrations/TestApplicationInitialization.kt
@@ -1,20 +1,19 @@
 package integrations
 
-import androidx.compose.material.Text
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.test.*
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import models.JetSettings
 import models.SettingsModel
-import org.junit.Rule
 import org.junit.Test
 import viewmodels.MainScreenViewModel
 import views.MainScreen
 
-class TestGraphLoading {
+class TestApplicationInitialization {
 	@OptIn(ExperimentalTestApi::class)
 	@Test
-	fun testMainScreenView() = runJetSettingsComposeUiTest(
+	fun testSimplePageSwitching() = runJetSettingsComposeUiTest(
 		context = { jetSettings: JetSettings ->
 			val settings: SettingsModel = SettingsModel.loadSettings(jetSettings)
 			val mainScreenViewModel = MainScreenViewModel(settings)

--- a/application/src/test/kotlin/integrations/TestGraphLoading.kt
+++ b/application/src/test/kotlin/integrations/TestGraphLoading.kt
@@ -1,0 +1,34 @@
+package integrations
+
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.*
+import models.JetSettings
+import models.SettingsModel
+import org.junit.Rule
+import org.junit.Test
+import viewmodels.MainScreenViewModel
+import views.MainScreen
+
+class TestGraphLoading {
+	@OptIn(ExperimentalTestApi::class)
+	@Test
+	fun testMainScreenView() = runJetSettingsComposeUiTest(
+		context = { jetSettings: JetSettings ->
+			val settings: SettingsModel = SettingsModel.loadSettings(jetSettings)
+			val mainScreenViewModel = MainScreenViewModel(settings)
+			MainScreen(mainScreenViewModel, jetSettings)
+		}
+	) { uiTest: ComposeUiTest ->
+		uiTest.onNodeWithTag("side-menu").assertExists("Not found side-menu")
+		uiTest.onNodeWithTag("side-menu-item#Home").assertExists("Not found side-menu-item#Home")
+		uiTest.onNodeWithTag("side-menu-item#Settings").assertExists("Not found side-menu-item#Settings")
+		uiTest.onNodeWithTag("home-page").assertExists("Not found home-page")
+		uiTest.onNodeWithTag("settings-page").assertDoesNotExist()
+		// Click on settings-tab item
+		uiTest.onNodeWithTag("side-menu-item#Settings").performClick()
+		uiTest.onNodeWithTag("settings-page").assertExists("Not found settings-page")
+		uiTest.onNodeWithTag("home-page").assertDoesNotExist()
+	}
+}

--- a/application/src/test/kotlin/integrations/Utils.kt
+++ b/application/src/test/kotlin/integrations/Utils.kt
@@ -1,0 +1,33 @@
+package integrations
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import models.JetSettings
+import themes.JetCorners
+import themes.JetFontFamily
+import themes.JetSize
+import themes.JetStyle
+
+@OptIn(ExperimentalTestApi::class)
+fun runJetSettingsComposeUiTest(
+	context: @Composable (JetSettings) -> (Unit),
+	assertions: (ComposeUiTest) -> Unit
+) = runComposeUiTest {
+	setContent {
+		val isDarkModeValue = isSystemInDarkTheme()
+		val jetSettings = JetSettings(
+			currentStyle = remember { mutableStateOf(JetStyle.Black) },
+			currentFontSize = remember { mutableStateOf(JetSize.Medium) },
+			currentCornersStyle = remember { mutableStateOf(JetCorners.Rounded) },
+			currentFontFamily = remember { mutableStateOf(JetFontFamily.Default) },
+			isDarkMode = remember { mutableStateOf(isDarkModeValue) }
+		)
+		context(jetSettings)
+	}
+	assertions(this)
+}


### PR DESCRIPTION
Добавлен простейший интеграционный тест, состоящий из таких действий
1. Загрузка приложения
2. Переход на страницу настроек

Выполняемые проверки:
1. Валидность загруженной `Home` страницы
2. Валидность загруженной `Settings` страницы